### PR TITLE
zk/enhc/sheet copilot

### DIFF
--- a/c1-sheet-copilot/src/app/TableContext.tsx
+++ b/c1-sheet-copilot/src/app/TableContext.tsx
@@ -4,9 +4,16 @@ import { createContext, useContext, useState, useCallback, ReactNode } from "rea
 
 type CellValue = string | number | null;
 
+interface TableData {
+  data: CellValue[][];
+  colHeaders?: string[];
+}
+
 interface TableContextType {
   threadId: string | null;
   setThreadId: (id: string) => void;
+  tableData: TableData | null;
+  setTableData: (data: CellValue[][], colHeaders?: string[]) => void;
   syncTableData: (data: CellValue[][], colHeaders?: string[]) => Promise<void>;
   fetchTableData: () => Promise<{ data: CellValue[][]; colHeaders: string[] } | null>;
 }
@@ -15,15 +22,23 @@ const TableContext = createContext<TableContextType | null>(null);
 
 export function TableProvider({ children }: { children: ReactNode }) {
   const [threadId, setThreadIdState] = useState<string | null>(null);
+  const [tableData, setTableDataState] = useState<TableData | null>(null);
 
   const setThreadId = useCallback((id: string) => {
     setThreadIdState(id);
   }, []);
 
+  const setTableData = useCallback((data: CellValue[][], colHeaders?: string[]) => {
+    setTableDataState({ data, colHeaders });
+  }, []);
+
   const syncTableData = useCallback(
     async (data: CellValue[][], colHeaders?: string[]) => {
+      // Always update local state, even without threadId
+      setTableDataState({ data, colHeaders });
+
       if (!threadId) {
-        console.warn("Cannot sync table data: no threadId set");
+        console.warn("Cannot sync table data to server: no threadId set");
         return;
       }
 
@@ -71,6 +86,8 @@ export function TableProvider({ children }: { children: ReactNode }) {
       value={{
         threadId,
         setThreadId,
+        tableData,
+        setTableData,
         syncTableData,
         fetchTableData,
       }}

--- a/c1-sheet-copilot/src/app/components.tsx
+++ b/c1-sheet-copilot/src/app/components.tsx
@@ -3,7 +3,6 @@
 import "@crayonai/react-ui/styles/index.css";
 import "handsontable/styles/handsontable.css";
 import "handsontable/styles/ht-theme-main.css";
-import { useOnAction } from "@thesysai/genui-sdk";
 import { useEffect, useRef, useCallback, useState } from "react";
 import type { CellChange, ChangeSource } from "handsontable/common";
 import { useTableContext } from "./TableContext";
@@ -18,8 +17,6 @@ function deepClone<T>(obj: T): T {
 interface SpreadsheetTableProps {
   data: CellValue[][];
   colHeaders?: string[];
-  height?: number;
-  title?: string;
 }
 
 // Lazy-loaded Handsontable component to avoid SSR issues
@@ -27,310 +24,29 @@ let HotTable: any = null;
 let HyperFormula: any = null;
 let modulesLoaded = false;
 
+// SpreadsheetTable: Syncs AI-generated data to the persistent spreadsheet (no visible rendering in chat)
 export const SpreadsheetTable = ({
   data: initialData,
   colHeaders: initialColHeaders,
-  height = 400,
-  title,
 }: SpreadsheetTableProps) => {
-  const onAction = useOnAction();
   const { syncTableData } = useTableContext();
-  const hotRef = useRef<any>(null);
-  const [isClient, setIsClient] = useState(false);
-  const [isInitialized, setIsInitialized] = useState(false);
-  
-  // Track props data to detect AI updates
-  const lastPropsDataRef = useRef<string>(JSON.stringify(initialData));
-  const lastPropsHeadersRef = useRef<string>(JSON.stringify(initialColHeaders));
-  
-  // Track if we're currently syncing to prevent loops
-  const isSyncingRef = useRef(false);
+  const hasSyncedRef = useRef(false);
+  const lastDataRef = useRef<string>("");
 
-  // Store colHeaders in ref for use in callbacks
-  const colHeadersRef = useRef(initialColHeaders);
-  colHeadersRef.current = initialColHeaders;
-
-  // Load Handsontable only on client side
+  // Sync data to context whenever props change
   useEffect(() => {
-    const loadHandsontable = async () => {
-      if (typeof window !== "undefined" && !modulesLoaded) {
-        const [hotModule, hfModule, registryModule] = await Promise.all([
-          import("@handsontable/react-wrapper"),
-          import("hyperformula"),
-          import("handsontable/registry"),
-        ]);
-
-        HotTable = hotModule.HotTable;
-        HyperFormula = hfModule.HyperFormula;
-        registryModule.registerAllModules();
-        modulesLoaded = true;
-
-        setIsClient(true);
-      } else if (modulesLoaded) {
-        setIsClient(true);
-      }
-    };
-
-    loadHandsontable();
-  }, []);
-
-  // Save data to backend
-  const saveData = useCallback(
-    async (data: CellValue[][]) => {
-      if (isSyncingRef.current) return;
-
-      try {
-        isSyncingRef.current = true;
-        await syncTableData(data, colHeadersRef.current);
-      } catch (error) {
-        console.error("Failed to save table data:", error);
-      } finally {
-        isSyncingRef.current = false;
-      }
-    },
-    [syncTableData]
-  );
-
-  // Load initial data after Handsontable mounts
-  useEffect(() => {
-    const hot = hotRef.current?.hotInstance;
-    if (!hot || isInitialized) return;
-
-    // Load initial data with a deep clone to ensure mutability
-    const mutableData = deepClone(initialData);
-    hot.loadData(mutableData);
+    const dataStr = JSON.stringify({ data: initialData, colHeaders: initialColHeaders });
     
-    // Update column headers
-    if (initialColHeaders) {
-      hot.updateSettings({ colHeaders: initialColHeaders });
+    // Only sync if data actually changed
+    if (dataStr !== lastDataRef.current) {
+      lastDataRef.current = dataStr;
+      syncTableData(initialData, initialColHeaders);
+      hasSyncedRef.current = true;
     }
-    
-    setIsInitialized(true);
-    
-    // Sync to backend
-    saveData(initialData);
-  }, [isClient, initialData, initialColHeaders, isInitialized, saveData]);
+  }, [initialData, initialColHeaders, syncTableData]);
 
-  // Handle prop changes (AI updates) after initial load
-  useEffect(() => {
-    const hot = hotRef.current?.hotInstance;
-    if (!hot || !isInitialized) return;
-
-    const propsDataStr = JSON.stringify(initialData);
-    const propsHeadersStr = JSON.stringify(initialColHeaders);
-    
-    // Check if data actually changed
-    if (propsDataStr !== lastPropsDataRef.current) {
-      lastPropsDataRef.current = propsDataStr;
-      
-      // Load new data with a deep clone
-      const mutableData = deepClone(initialData);
-      hot.loadData(mutableData);
-      
-      // Sync to backend
-      saveData(initialData);
-    }
-    
-    // Update column headers if changed
-    if (propsHeadersStr !== lastPropsHeadersRef.current) {
-      lastPropsHeadersRef.current = propsHeadersStr;
-      hot.updateSettings({ colHeaders: initialColHeaders || true });
-    }
-  }, [initialData, initialColHeaders, isInitialized, saveData]);
-
-  // Safe wrapper for onAction that catches errors
-  const safeOnAction = useCallback(
-    (humanMessage: string, llmMessage: string) => {
-      try {
-        if (onAction) {
-          onAction(humanMessage, llmMessage);
-        }
-      } catch (error) {
-        console.debug("onAction not available:", error);
-      }
-    },
-    [onAction]
-  );
-
-  // Autosave after changes
-  const handleAfterChange = useCallback(
-    (changes: CellChange[] | null, source: ChangeSource) => {
-      // Skip saving on initial data load
-      if (source === "loadData") {
-        return;
-      }
-
-      if (!changes) return;
-
-      const hot = hotRef.current?.hotInstance;
-      if (!hot) return;
-
-      // Get all data and save it
-      const allData = hot.getData() as CellValue[][];
-      saveData(allData);
-
-      // Notify AI about user edits
-      if (source === "edit") {
-        const colHeaders = colHeadersRef.current;
-        const changeDescriptions = changes.map(([row, col, oldVal, newVal]) => {
-          const colName =
-            colHeaders && typeof col === "number" ? colHeaders[col] : `Column ${col}`;
-          return `Cell at row ${row + 1}, ${colName}: "${oldVal}" → "${newVal}"`;
-        });
-
-        safeOnAction(
-          "Cell Updated",
-          `User made the following changes to the spreadsheet:\n${changeDescriptions.join("\n")}`
-        );
-      }
-    },
-    [saveData, safeOnAction]
-  );
-
-  // Handle row creation
-  const handleAfterCreateRow = useCallback(
-    (index: number, amount: number) => {
-      const hot = hotRef.current?.hotInstance;
-      if (hot) {
-        saveData(hot.getData() as CellValue[][]);
-        safeOnAction(
-          "Rows Added",
-          `User added ${amount} row(s) at position ${index + 1}`
-        );
-      }
-    },
-    [saveData, safeOnAction]
-  );
-
-  // Handle row removal
-  const handleAfterRemoveRow = useCallback(
-    (index: number, amount: number) => {
-      const hot = hotRef.current?.hotInstance;
-      if (hot) {
-        saveData(hot.getData() as CellValue[][]);
-        safeOnAction(
-          "Rows Removed",
-          `User removed ${amount} row(s) starting at position ${index + 1}`
-        );
-      }
-    },
-    [saveData, safeOnAction]
-  );
-
-  // Handle column creation
-  const handleAfterCreateCol = useCallback(
-    (index: number, amount: number) => {
-      const hot = hotRef.current?.hotInstance;
-      if (hot) {
-        saveData(hot.getData() as CellValue[][]);
-        safeOnAction(
-          "Columns Added",
-          `User added ${amount} column(s) at position ${index + 1}`
-        );
-      }
-    },
-    [saveData, safeOnAction]
-  );
-
-  // Handle column removal
-  const handleAfterRemoveCol = useCallback(
-    (index: number, amount: number) => {
-      const hot = hotRef.current?.hotInstance;
-      if (hot) {
-        saveData(hot.getData() as CellValue[][]);
-        safeOnAction(
-          "Columns Removed",
-          `User removed ${amount} column(s) starting at position ${index + 1}`
-        );
-      }
-    },
-    [saveData, safeOnAction]
-  );
-
-  // Show loading state while Handsontable is loading
-  if (!isClient || !HotTable || !HyperFormula) {
-    return (
-      <div className="w-full rounded-xl border border-white/10 bg-gradient-to-b from-neutral-900/80 to-black/60 p-4 shadow-xl">
-        {title && (
-          <h3 className="mb-4 text-lg font-semibold tracking-tight text-neutral-100">
-            {title}
-          </h3>
-        )}
-        <div
-          className="flex items-center justify-center rounded-lg bg-neutral-800/50"
-          style={{ height }}
-        >
-          <div className="text-neutral-400">Loading spreadsheet...</div>
-        </div>
-        <div className="mt-3 flex items-center justify-between text-xs text-neutral-400">
-          <span>
-            {initialData.length} rows × {initialColHeaders?.length || initialData[0]?.length || 0} columns
-          </span>
-          <span>Right-click for options • Formulas supported (=SUM, =AVERAGE, etc.)</span>
-        </div>
-      </div>
-    );
-  }
-
-  const HotTableComponent = HotTable;
-  const HyperFormulaEngine = HyperFormula;
-
-  return (
-    <div className="w-full rounded-xl border border-white/10 bg-gradient-to-b from-neutral-900/80 to-black/60 p-4 shadow-xl">
-      {title && (
-        <h3 className="mb-4 text-lg font-semibold tracking-tight text-neutral-100">
-          {title}
-        </h3>
-      )}
-      <div className="overflow-hidden rounded-lg">
-        <HotTableComponent
-          ref={hotRef}
-          startRows={initialData.length}
-          startCols={initialColHeaders?.length || initialData[0]?.length || 6}
-          colHeaders={initialColHeaders || true}
-          rowHeaders={true}
-          height={height}
-          stretchH="all"
-          formulas={{
-            engine: HyperFormulaEngine,
-          }}
-          contextMenu={[
-            "row_above",
-            "row_below",
-            "---------",
-            "col_left",
-            "col_right",
-            "---------",
-            "remove_row",
-            "remove_col",
-            "---------",
-            "undo",
-            "redo",
-            "---------",
-            "copy",
-            "cut",
-          ]}
-          manualColumnResize={true}
-          manualRowResize={true}
-          autoWrapRow={true}
-          autoWrapCol={true}
-          afterChange={handleAfterChange}
-          afterCreateRow={handleAfterCreateRow}
-          afterRemoveRow={handleAfterRemoveRow}
-          afterCreateCol={handleAfterCreateCol}
-          afterRemoveCol={handleAfterRemoveCol}
-          className="htDark"
-          licenseKey="non-commercial-and-evaluation"
-        />
-      </div>
-      <div className="mt-3 flex items-center justify-between text-xs text-neutral-400">
-        <span>
-          {initialData.length} rows × {initialColHeaders?.length || initialData[0]?.length || 0} columns
-        </span>
-        <span>Right-click for options • Formulas supported (=SUM, =AVERAGE, etc.)</span>
-      </div>
-    </div>
-  );
+  // Render nothing - data is shown in the persistent spreadsheet panel
+  return null;
 };
 
 // Default empty spreadsheet data
@@ -351,8 +67,10 @@ const DEFAULT_DATA: CellValue[][] = [
 export const PersistentSpreadsheet = () => {
   const { tableData, syncTableData } = useTableContext();
   const hotRef = useRef<any>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [isClient, setIsClient] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
+  const [containerHeight, setContainerHeight] = useState(400);
 
   // Track context data to detect updates from AI
   const lastContextDataRef = useRef<string>("");
@@ -362,6 +80,27 @@ export const PersistentSpreadsheet = () => {
 
   // Store colHeaders in ref for use in callbacks
   const colHeadersRef = useRef<string[] | undefined>(tableData?.colHeaders);
+
+  // Calculate container height on mount and resize
+  useEffect(() => {
+    const updateHeight = () => {
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect();
+        setContainerHeight(rect.height > 0 ? rect.height : 400);
+      }
+    };
+
+    updateHeight();
+    window.addEventListener("resize", updateHeight);
+    
+    // Also update after a short delay to handle initial render
+    const timeout = setTimeout(updateHeight, 100);
+    
+    return () => {
+      window.removeEventListener("resize", updateHeight);
+      clearTimeout(timeout);
+    };
+  }, [isClient]);
 
   // Load Handsontable only on client side
   useEffect(() => {
@@ -516,15 +255,14 @@ export const PersistentSpreadsheet = () => {
           {currentData.length} rows × {currentHeaders?.length || currentData[0]?.length || 0} columns
         </p>
       </div>
-      <div className="flex-1 overflow-hidden">
+      <div ref={containerRef} className="flex-1 overflow-hidden">
         <HotTableComponent
           ref={hotRef}
           startRows={currentData.length}
           startCols={currentHeaders?.length || currentData[0]?.length || 6}
           colHeaders={currentHeaders || true}
           rowHeaders={true}
-          height="100%"
-          width="100%"
+          height={containerHeight}
           stretchH="all"
           formulas={{
             engine: HyperFormulaEngine,

--- a/c1-sheet-copilot/src/app/components.tsx
+++ b/c1-sheet-copilot/src/app/components.tsx
@@ -332,3 +332,235 @@ export const SpreadsheetTable = ({
     </div>
   );
 };
+
+// Default empty spreadsheet data
+const DEFAULT_DATA: CellValue[][] = [
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+  [null, null, null, null, null, null],
+];
+
+// Persistent spreadsheet component that displays data from TableContext
+export const PersistentSpreadsheet = () => {
+  const { tableData, syncTableData } = useTableContext();
+  const hotRef = useRef<any>(null);
+  const [isClient, setIsClient] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Track context data to detect updates from AI
+  const lastContextDataRef = useRef<string>("");
+
+  // Track if we're currently syncing to prevent loops
+  const isSyncingRef = useRef(false);
+
+  // Store colHeaders in ref for use in callbacks
+  const colHeadersRef = useRef<string[] | undefined>(tableData?.colHeaders);
+
+  // Load Handsontable only on client side
+  useEffect(() => {
+    const loadHandsontable = async () => {
+      if (typeof window !== "undefined" && !modulesLoaded) {
+        const [hotModule, hfModule, registryModule] = await Promise.all([
+          import("@handsontable/react-wrapper"),
+          import("hyperformula"),
+          import("handsontable/registry"),
+        ]);
+
+        HotTable = hotModule.HotTable;
+        HyperFormula = hfModule.HyperFormula;
+        registryModule.registerAllModules();
+        modulesLoaded = true;
+
+        setIsClient(true);
+      } else if (modulesLoaded) {
+        setIsClient(true);
+      }
+    };
+
+    loadHandsontable();
+  }, []);
+
+  // Save data to context and backend
+  const saveData = useCallback(
+    async (data: CellValue[][], colHeaders?: string[]) => {
+      if (isSyncingRef.current) return;
+
+      try {
+        isSyncingRef.current = true;
+        await syncTableData(data, colHeaders || colHeadersRef.current);
+      } catch (error) {
+        console.error("Failed to save table data:", error);
+      } finally {
+        isSyncingRef.current = false;
+      }
+    },
+    [syncTableData]
+  );
+
+  // Initialize with default or context data
+  useEffect(() => {
+    const hot = hotRef.current?.hotInstance;
+    if (!hot || isInitialized) return;
+
+    const data = tableData?.data || DEFAULT_DATA;
+    const colHeaders = tableData?.colHeaders;
+    
+    const mutableData = deepClone(data);
+    hot.loadData(mutableData);
+    
+    if (colHeaders) {
+      hot.updateSettings({ colHeaders });
+      colHeadersRef.current = colHeaders;
+    }
+    
+    lastContextDataRef.current = JSON.stringify(tableData);
+    setIsInitialized(true);
+  }, [isClient, tableData, isInitialized]);
+
+  // Handle context data changes (from AI updates via chat)
+  useEffect(() => {
+    const hot = hotRef.current?.hotInstance;
+    if (!hot || !isInitialized || isSyncingRef.current) return;
+
+    const contextDataStr = JSON.stringify(tableData);
+    
+    // Only update if context data actually changed (from AI)
+    if (contextDataStr !== lastContextDataRef.current && tableData?.data) {
+      lastContextDataRef.current = contextDataStr;
+      
+      const mutableData = deepClone(tableData.data);
+      hot.loadData(mutableData);
+      
+      if (tableData.colHeaders) {
+        hot.updateSettings({ colHeaders: tableData.colHeaders });
+        colHeadersRef.current = tableData.colHeaders;
+      }
+    }
+  }, [tableData, isInitialized]);
+
+  // Autosave after changes
+  const handleAfterChange = useCallback(
+    (changes: CellChange[] | null, source: ChangeSource) => {
+      if (source === "loadData") return;
+      if (!changes) return;
+
+      const hot = hotRef.current?.hotInstance;
+      if (!hot) return;
+
+      const allData = hot.getData() as CellValue[][];
+      saveData(allData);
+    },
+    [saveData]
+  );
+
+  // Handle row creation
+  const handleAfterCreateRow = useCallback(() => {
+    const hot = hotRef.current?.hotInstance;
+    if (hot) {
+      saveData(hot.getData() as CellValue[][]);
+    }
+  }, [saveData]);
+
+  // Handle row removal
+  const handleAfterRemoveRow = useCallback(() => {
+    const hot = hotRef.current?.hotInstance;
+    if (hot) {
+      saveData(hot.getData() as CellValue[][]);
+    }
+  }, [saveData]);
+
+  // Handle column creation
+  const handleAfterCreateCol = useCallback(() => {
+    const hot = hotRef.current?.hotInstance;
+    if (hot) {
+      saveData(hot.getData() as CellValue[][]);
+    }
+  }, [saveData]);
+
+  // Handle column removal
+  const handleAfterRemoveCol = useCallback(() => {
+    const hot = hotRef.current?.hotInstance;
+    if (hot) {
+      saveData(hot.getData() as CellValue[][]);
+    }
+  }, [saveData]);
+
+  // Show loading state while Handsontable is loading
+  if (!isClient || !HotTable || !HyperFormula) {
+    return (
+      <div className="persistent-spreadsheet h-full flex flex-col">
+        <div className="flex-1 flex items-center justify-center bg-neutral-900/50 rounded-lg">
+          <div className="text-neutral-400">Loading spreadsheet...</div>
+        </div>
+      </div>
+    );
+  }
+
+  const HotTableComponent = HotTable;
+  const HyperFormulaEngine = HyperFormula;
+  const currentData = tableData?.data || DEFAULT_DATA;
+  const currentHeaders = tableData?.colHeaders;
+
+  return (
+    <div className="persistent-spreadsheet h-full flex flex-col">
+      <div className="flex-none px-4 py-3 border-b border-white/10">
+        <h2 className="text-lg font-semibold text-neutral-100">Spreadsheet</h2>
+        <p className="text-xs text-neutral-400 mt-1">
+          {currentData.length} rows × {currentHeaders?.length || currentData[0]?.length || 0} columns
+        </p>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        <HotTableComponent
+          ref={hotRef}
+          startRows={currentData.length}
+          startCols={currentHeaders?.length || currentData[0]?.length || 6}
+          colHeaders={currentHeaders || true}
+          rowHeaders={true}
+          height="100%"
+          width="100%"
+          stretchH="all"
+          formulas={{
+            engine: HyperFormulaEngine,
+          }}
+          contextMenu={[
+            "row_above",
+            "row_below",
+            "---------",
+            "col_left",
+            "col_right",
+            "---------",
+            "remove_row",
+            "remove_col",
+            "---------",
+            "undo",
+            "redo",
+            "---------",
+            "copy",
+            "cut",
+          ]}
+          manualColumnResize={true}
+          manualRowResize={true}
+          autoWrapRow={true}
+          autoWrapCol={true}
+          afterChange={handleAfterChange}
+          afterCreateRow={handleAfterCreateRow}
+          afterRemoveRow={handleAfterRemoveRow}
+          afterCreateCol={handleAfterCreateCol}
+          afterRemoveCol={handleAfterRemoveCol}
+          className="htDark"
+          licenseKey="non-commercial-and-evaluation"
+        />
+      </div>
+      <div className="flex-none px-4 py-2 border-t border-white/10 text-xs text-neutral-400">
+        Right-click for options • Formulas supported (=SUM, =AVERAGE, etc.)
+      </div>
+    </div>
+  );
+};

--- a/c1-sheet-copilot/src/app/components.tsx
+++ b/c1-sheet-copilot/src/app/components.tsx
@@ -231,6 +231,26 @@ export const PersistentSpreadsheet = () => {
     }
   }, [saveData]);
 
+  // Export to CSV
+  const handleExportCSV = useCallback(() => {
+    const hot = hotRef.current?.hotInstance;
+    if (!hot) return;
+
+    const exportPlugin = hot.getPlugin('exportFile');
+    exportPlugin?.downloadFile('csv', {
+      bom: false,
+      columnDelimiter: ',',
+      columnHeaders: true,
+      exportHiddenColumns: true,
+      exportHiddenRows: true,
+      fileExtension: 'csv',
+      filename: 'Spreadsheet_[YYYY]-[MM]-[DD]',
+      mimeType: 'text/csv',
+      rowDelimiter: '\r\n',
+      rowHeaders: false,
+    });
+  }, []);
+
   // Show loading state while Handsontable is loading
   if (!isClient || !HotTable || !HyperFormula) {
     return (
@@ -250,10 +270,25 @@ export const PersistentSpreadsheet = () => {
   return (
     <div className="persistent-spreadsheet h-full flex flex-col">
       <div className="flex-none px-4 py-3 border-b border-white/10">
-        <h2 className="text-lg font-semibold text-neutral-100">Spreadsheet</h2>
-        <p className="text-xs text-neutral-400 mt-1">
-          {currentData.length} rows × {currentHeaders?.length || currentData[0]?.length || 0} columns
-        </p>
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-neutral-100">Spreadsheet</h2>
+            <p className="text-xs text-neutral-400 mt-1">
+              {currentData.length} rows × {currentHeaders?.length || currentData[0]?.length || 0} columns
+            </p>
+          </div>
+          <button
+            onClick={handleExportCSV}
+            className="px-3 py-1.5 text-sm bg-neutral-700 hover:bg-neutral-600 text-neutral-100 rounded-md transition-colors flex items-center gap-2"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            Export CSV
+          </button>
+        </div>
       </div>
       <div ref={containerRef} className="flex-1 overflow-hidden">
         <HotTableComponent

--- a/c1-sheet-copilot/src/app/globals.css
+++ b/c1-sheet-copilot/src/app/globals.css
@@ -7,6 +7,13 @@
   --foreground: #ededed;
 }
 
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   color: var(--foreground);
   background: var(--background);
@@ -118,13 +125,31 @@ body {
 /* Persistent spreadsheet styling */
 .persistent-spreadsheet {
   background-color: #0f0f0f;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
+.persistent-spreadsheet > div:first-child {
+  flex-shrink: 0;
+}
+
+.persistent-spreadsheet > div:nth-child(2) {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.persistent-spreadsheet > div:last-child {
+  flex-shrink: 0;
+}
+
+/* Ensure Handsontable is interactive */
 .persistent-spreadsheet .handsontable {
-  height: 100% !important;
+  position: relative;
+  z-index: 1;
 }
 
-/* Ensure the Handsontable container fills the space */
 .persistent-spreadsheet .wtHolder {
-  height: 100% !important;
+  width: 100% !important;
 }

--- a/c1-sheet-copilot/src/app/globals.css
+++ b/c1-sheet-copilot/src/app/globals.css
@@ -92,3 +92,39 @@ body {
 .crayon-shell-thread-composer__input {
   height: unset !important;
 }
+
+/* Side-by-side layout */
+.app-layout {
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.spreadsheet-panel {
+  flex: 0 0 60%;
+  height: 100%;
+  background-color: #0f0f0f;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  overflow: hidden;
+}
+
+.chat-panel {
+  flex: 0 0 40%;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* Persistent spreadsheet styling */
+.persistent-spreadsheet {
+  background-color: #0f0f0f;
+}
+
+.persistent-spreadsheet .handsontable {
+  height: 100% !important;
+}
+
+/* Ensure the Handsontable container fills the space */
+.persistent-spreadsheet .wtHolder {
+  height: 100% !important;
+}

--- a/c1-sheet-copilot/src/app/globals.css
+++ b/c1-sheet-copilot/src/app/globals.css
@@ -109,7 +109,8 @@ body {
 }
 
 .spreadsheet-panel {
-  flex: 0 0 60%;
+  flex: 1 1 auto;
+  min-width: 0;
   height: 100%;
   background-color: #0f0f0f;
   border-right: 1px solid rgba(255, 255, 255, 0.1);
@@ -117,7 +118,7 @@ body {
 }
 
 .chat-panel {
-  flex: 0 0 40%;
+  flex: 0 0 400px;
   height: 100%;
   overflow: hidden;
 }

--- a/c1-sheet-copilot/src/app/page.tsx
+++ b/c1-sheet-copilot/src/app/page.tsx
@@ -7,7 +7,7 @@ import {
   useThreadListManager,
   useThreadManager,
 } from "@thesysai/genui-sdk";
-import { SpreadsheetTable } from "./components";
+import { SpreadsheetTable, PersistentSpreadsheet } from "./components";
 import { TableProvider, useTableContext } from "./TableContext";
 import { useEffect } from "react";
 
@@ -93,7 +93,16 @@ export default function Home() {
   return (
     <ThemeProvider mode="dark">
       <TableProvider>
-        <ChatWithTable />
+        <div className="app-layout">
+          {/* Left panel: Persistent Spreadsheet */}
+          <div className="spreadsheet-panel">
+            <PersistentSpreadsheet />
+          </div>
+          {/* Right panel: Chat */}
+          <div className="chat-panel">
+            <ChatWithTable />
+          </div>
+        </div>
       </TableProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION

---
## EntelligenceAI PR Summary 
 This PR adds CSV export capability to the PersistentSpreadsheet component with a new export button in the UI header.
- Implemented `handleExportCSV` callback using Handsontable's exportFile plugin
- Configured export options to include column headers and hidden rows/columns
- Added timestamp-based filename generation for exported CSV files
- Added export button with download icon SVG to header section
- Positioned button using flexbox layout alongside spreadsheet title and dimensions
- Applied hover states and neutral color scheme styling to export button 

